### PR TITLE
add ability to make holes generic

### DIFF
--- a/src/expand.jl
+++ b/src/expand.jl
@@ -66,9 +66,6 @@ function collect_expansions(
             # node case - group with other nodes that have same number of children (and head if autoexpand_head is on)
             head = compute_head(config, match.holes[end])
 
-            if string(head) == "/seq" # this is a sequence
-                continue
-            end
             childcount = length(match.holes[end].children)
             matches_for_leaf = get!(matches_of_node, (head, childcount)) do
                 Match[]

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -80,11 +80,6 @@ const SExpr = SExprGeneric{Match,Metadata}
 const Program = ProgramGeneric{Match,Metadata}
 const TreeNodeHole = SExpr
 
-struct RemainingSequenceHole <: Hole{SExpr}
-    root_node::SExpr
-    num_consumed::Int
-end
-
 function sexpr_node(children::Vector{SExpr}; parent=nothing)
     expr = SExpr(nothing, children, parent, nothing, nothing)
     for (i,child) in enumerate(children)

--- a/src/utility.jl
+++ b/src/utility.jl
@@ -90,7 +90,7 @@ function delta_local_utility(config, match, expansion::PossibleExpansion{Abstrac
         # actually do nothing here
     else
         # Eqn 12: https://arxiv.org/pdf/2211.16605.pdf (multiuse utility; (usages-1)*cost(arg))
-        return match.holes[end].content.metadata.size;
+        return match.holes[end].metadata.size;
     end
 end
 

--- a/src/utility.jl
+++ b/src/utility.jl
@@ -90,7 +90,7 @@ function delta_local_utility(config, match, expansion::PossibleExpansion{Abstrac
         # actually do nothing here
     else
         # Eqn 12: https://arxiv.org/pdf/2211.16605.pdf (multiuse utility; (usages-1)*cost(arg))
-        return match.holes[end].metadata.size;
+        return match.holes[end].content.metadata.size;
     end
 end
 


### PR DESCRIPTION
Before: Times taken 30.1, 30.1, 30.1; average: 30.1
After: Times taken 36.1, 36.6, 36.5; average: 36.4

+21% time taken

Just the very act of making the hole generic is causing these issues, not the type checks, etc.

When using a struct for TreeNodeHole: time taken 40.0, 39.8, 39.9; average: 39.9
