### PR TITLE
SPEED: Subtract out the abstraction

### DIFF
--- a/src/utility.jl
+++ b/src/utility.jl
@@ -72,7 +72,7 @@ function upper_bound_with_conflicts(search_state, expansion=nothing)::Float32
         )
         offset == 0 && break
     end
-    bound
+    bound - size(search_state.abstraction.body, search_state.config.size_by_symbol)
 end
 
 function delta_local_utility(config, match, expansion::PossibleExpansion{SymbolExpansion})

--- a/src/utility.jl
+++ b/src/utility.jl
@@ -36,7 +36,10 @@ function upper_bound_with_conflicts(search_state, expansion=nothing)::Float32
     else
         expansion.matches
     end
-    issorted(matches, by=m -> m.expr.metadata.id) || error("matches is not sorted")
+
+        if length(matches) == 1
+        return 0
+    end
 
     bound = 0.0
     offset = length(matches)

--- a/src/utility.jl
+++ b/src/utility.jl
@@ -37,7 +37,7 @@ function upper_bound_with_conflicts(search_state, expansion=nothing)::Float32
         expansion.matches
     end
 
-        if length(matches) == 1
+    if length(matches) == 1
         return 0
     end
 


### PR DESCRIPTION
Before: Times taken 51.1, 50.5, 50.5; average: 50.7
After: Times taken 53.9, 55.0, 54.7; average: 54.5

Performance gets worse by 7.5% :sob: 

However, when running one iteration on data/imperative_realistic/0.json, you have

before:
```
Stitch.Stats(
    expansions=4751
    completed=215
    comparable_worklist_steps=4276
    )
```

after:
```
Stitch.Stats(
    expansions=4469
    completed=181
    comparable_worklist_steps=4056
    )
```

The number of expansions is reduced by about 6%. This should be leverageable into a performance improvement

on the choicevar branch the difference is

before:
```
Stitch.Stats(
    expansions=86034
    completed=2711
    comparable_worklist_steps=79425
    )
```

after:
```
Stitch.Stats(
    expansions=83446
    completed=2643
    comparable_worklist_steps=76956
    )
```

which is a difference of only about 3%. Not sure if it makes sense to pursue this