### PR TITLE
make sure sum-no-variables is correct

### DIFF
--- a/src/utility.jl
+++ b/src/utility.jl
@@ -107,7 +107,7 @@ function upper_bound_sum_no_variables(search_state, expansion=nothing)::Float32
     sum(sum_no_variables, matches, init=0.0)
 end
 
-sum_no_variables(match::Match) = match.local_utility + match.holes_size
+sum_no_variables(match::Match) = max(match.local_utility + match.holes_size, 0)
 sum_no_variables(match::MatchPossibilities) = maximum([sum_no_variables(x) for x in match.alternatives])
 
 function delta_local_utility(config, match, expansion::SymbolExpansion)


### PR DESCRIPTION
Time:

Before: Individual times: [48.59, 48.52, 49.37, 48.35, 48.46]. Median: 48.52
After: Individual times: [48.3, 49.5, 47.95, 48.26, 48.39]. Median: 48.3
Change: -0.5%

Fortunately, no major change

6.json:

Before: expansions=44112, expansions=135733, expansions=157404
After: expansions=44327, expansions=135992, expansions=157648

Pretty similar