### PR TITLE
BUGFIX: don't drop matches when there's only some match possibility updates

### DIFF
--- a/src/expand.jl
+++ b/src/expand.jl
@@ -513,6 +513,10 @@ function expand!(search_state::SearchState{MatchPossibilities}, expansion, hole)
             end
             match_poss = MatchPossibilities(updated_matches)
             push!(new_match_poss, match_poss)
+        else
+            if whole_list_update
+                push!(new_match_poss, match_poss)
+            end
         end
     end
     if !whole_list_update


### PR DESCRIPTION
I don't think there's any cases where this happens now, but it should be fixed in advance of the next PR

Time change from main to fix-whole-update: no reason that it should have changed
Before: Individual times: [36.15, 36.15, 35.92, 35.92, 36.11]. Median: 36.11
After: Individual times: [35.92, 35.78, 35.72, 35.85, 35.74]. Median: 35.78
Change: -0.9%
