### PR TITLE
SPEED: merge match possibilities at termination

### DIFF
--- a/src/expand.jl
+++ b/src/expand.jl
@@ -509,7 +509,7 @@ function expand!(search_state::SearchState{MatchPossibilities}, expansion, hole)
             updated_matches = match_poss.alternatives
         end
         if typeof(expansion) === SequenceTerminatorExpansion
-            new_matches = collapse_by_group_id(updated_matches)
+            new_matches = collapse_equivalent_matches(updated_matches)
             if !isnothing(new_matches)
                 match_poss_update = true
                 updated_matches = new_matches
@@ -541,7 +541,7 @@ function expand_abstraction!(expansion::SyntacticLeafExpansion, hole, holes, abs
     hole.leaf = expansion.leaf
 end
 
-function collapse_by_group_id(updated_matches)
+function collapse_equivalent_matches(updated_matches)
     if length(updated_matches) > 1
         was_updated = false
         best_match_per_id = Dict{Tuple{Vector{Int64}, Vector{Symbol}, Vector{Int64}},Match}()

--- a/src/expand.jl
+++ b/src/expand.jl
@@ -545,7 +545,6 @@ function collapse_equivalent_matches(updated_matches)
     if length(updated_matches) > 1
         was_updated = false
         best_match_per_id = Dict{Tuple{Vector{Int64}, Vector{Symbol}, Vector{Int64}},Match}()
-        other_matches = Match[]
         for m in updated_matches
             id = match_key(m)
             if haskey(best_match_per_id, id)
@@ -558,10 +557,7 @@ function collapse_equivalent_matches(updated_matches)
             end
         end
         if was_updated
-            for (_, v) in best_match_per_id
-                push!(other_matches, v)
-            end
-            return other_matches
+            return [v for (_, v) in best_match_per_id]
         end
     end
     return nothing

--- a/src/expand.jl
+++ b/src/expand.jl
@@ -1031,7 +1031,7 @@ function unexpand_match!(expansion::SequenceChoiceVarExpansion, match::Match)
     @assert expansion.idx == length(match.choice_var_captures)
 end
 
-const MatchKey = Tuple{Vector{Int64},Vector{Symbol},Vector{Int64}}
+const MatchKey = Tuple{Vector{Int64},Vector{Symbol},Vector{Tuple{Symbol, Int64}}}
 
 function collapse_equivalent_matches(expansion::Expansion, updated_matches)
     return nothing
@@ -1075,8 +1075,8 @@ end
 
 # ensure that the struct hash is unique for each hole
 # since these are positive integers, we can dove-tail them
-hole_struct_hash(x::TreeNodeHole) = 2 * x.metadata.struct_hash
-hole_struct_hash(x::RemainingSequenceHole) = 2 * hole_struct_hash(x.root_node) + 1
+hole_struct_hash(x::TreeNodeHole) = (:TreeNodeHole, x.metadata.struct_hash)
+hole_struct_hash(x::RemainingSequenceHole) = (:RemainingSequenceHole, (x.root_node.metadata.struct_hash << 32) + x.num_consumed)
 
 
 # https://arxiv.org/pdf/2211.16605.pdf (section 4.3)

--- a/src/expand.jl
+++ b/src/expand.jl
@@ -508,12 +508,10 @@ function expand!(search_state::SearchState{MatchPossibilities}, expansion, hole)
         if !match_poss_update
             updated_matches = match_poss.alternatives
         end
-        if typeof(expansion) === SequenceTerminatorExpansion
-            new_matches = collapse_equivalent_matches(updated_matches)
-            if !isnothing(new_matches)
-                match_poss_update = true
-                updated_matches = new_matches
-            end
+        new_matches = collapse_equivalent_matches(expansion, updated_matches)
+        if !isnothing(new_matches)
+            match_poss_update = true
+            updated_matches = new_matches
         end
         if match_poss_update
             if !whole_list_update
@@ -540,49 +538,6 @@ function expand_abstraction!(expansion::SyntacticLeafExpansion, hole, holes, abs
     # set the head symbol of the hole
     hole.leaf = expansion.leaf
 end
-
-const MatchKey = Tuple{Vector{Int64},Vector{Symbol},Vector{Int64}}
-
-function collapse_equivalent_matches(updated_matches)
-    if length(updated_matches) <= 1
-        return nothing
-    end
-    was_updated = false
-    best_match_per_id = Dict{MatchKey,Match}()
-    for m in updated_matches
-        id = match_key(m)
-        if haskey(best_match_per_id, id)
-            was_updated = true
-            if best_match_per_id[id].local_utility < m.local_utility
-                best_match_per_id[id] = m
-            end
-        else
-            best_match_per_id[id] = m
-        end
-    end
-    if !was_updated
-        return nothing
-    end
-    return [v for (_, v) in best_match_per_id]
-end
-
-function match_key(m::Match)::MatchKey
-    # we consider matches equivalent if from now on they will be
-    # identical in what expansions can be applied to them, and how
-    # those expansions will affect the local utility.
-
-    # the only state that matters for this is the holes as well as
-    # arguments that can potentially be used for variable reuse
-    # (i.e. the unique_args and symbolic arguments)
-    unique_args = [x.metadata.struct_hash for x in m.unique_args]
-    holes = [hole_struct_hash(x) for x in m.holes]
-    return (unique_args, m.sym_of_idx, holes)
-end
-
-# ensure that the struct hash is unique for each hole
-# since these are positive integers, we can dove-tail them
-hole_struct_hash(x::TreeNodeHole) = 2 * x.metadata.struct_hash
-hole_struct_hash(x::RemainingSequenceHole) = 2 * hole_struct_hash(x.root_node) + 1
 
 function expand_match!(expansion::SyntacticLeafExpansion, match::Match)::Nothing
     hole = pop!(match.holes)::TreeNodeHole
@@ -1075,6 +1030,54 @@ function unexpand_match!(expansion::SequenceChoiceVarExpansion, match::Match)
 
     @assert expansion.idx == length(match.choice_var_captures)
 end
+
+const MatchKey = Tuple{Vector{Int64},Vector{Symbol},Vector{Int64}}
+
+function collapse_equivalent_matches(expansion::Expansion, updated_matches)
+    return nothing
+end
+
+function collapse_equivalent_matches(expansion::SequenceTerminatorExpansion, updated_matches)
+    if length(updated_matches) <= 1
+        return nothing
+    end
+    was_updated = false
+    best_match_per_id = Dict{MatchKey,Match}()
+    for m in updated_matches
+        id = match_key(m)
+        if haskey(best_match_per_id, id)
+            was_updated = true
+            if best_match_per_id[id].local_utility < m.local_utility
+                best_match_per_id[id] = m
+            end
+        else
+            best_match_per_id[id] = m
+        end
+    end
+    if !was_updated
+        return nothing
+    end
+    return [v for (_, v) in best_match_per_id]
+end
+
+function match_key(m::Match)::MatchKey
+    # we consider matches equivalent if from now on they will be
+    # identical in what expansions can be applied to them, and how
+    # those expansions will affect the local utility.
+
+    # the only state that matters for this is the holes as well as
+    # arguments that can potentially be used for variable reuse
+    # (i.e. the unique_args and symbolic arguments)
+    unique_args = [x.metadata.struct_hash for x in m.unique_args]
+    holes = [hole_struct_hash(x) for x in m.holes]
+    return (unique_args, m.sym_of_idx, holes)
+end
+
+# ensure that the struct hash is unique for each hole
+# since these are positive integers, we can dove-tail them
+hole_struct_hash(x::TreeNodeHole) = 2 * x.metadata.struct_hash
+hole_struct_hash(x::RemainingSequenceHole) = 2 * hole_struct_hash(x.root_node) + 1
+
 
 # https://arxiv.org/pdf/2211.16605.pdf (section 4.3)
 function strictly_dominated(search_state)


### PR DESCRIPTION
The time taken in the actual `collapse_equivalent_matches` function is quite low so even though it seems inefficient this does not matter. (It rounds to 0% when profiling A.json). I'm guessing it is low because it's called very rarely

# Overall

Time change from main to merge-at-terminate-2
Before: Individual times: [39.95, 39.39, 39.78, 39.82, 39.64]. Median: 39.78
After: Individual times: [38.47, 37.58, 37.94, 38.05, 37.58]. Median: 37.94
Change: -4.6%

# On A.json:

## Expansions
Before: Individual times: [40.92, 42.16, 43.23, 42.95, 43.05]. Median: 42.95
After: Individual times: [36.34, 37.94, 38.77, 38.87, 38.42]. Median: 38.42
Change: -10.5%

## Matches considered
Before: matches_considered=18684744; matches_considered=23009712; matches_considered=3352704; total=45047160
After: matches_considered=15580400; matches_considered=19467296; matches_considered=2936840; total=37984536
Difference: -15.6%

## Time

--path data_slow/A.json:
Before: Individual times: [41.26, 43.75, 43.37, 43.9, 43.77]. Median: 43.75
After: Individual times: [36.92, 38.62, 39.62, 38.95, 39.1]. Median: 38.95
Change: -11.0%



# On data/imperative/realistic-nested-sequence.json

Before: expansions=5644, matches_considered=104088
After: expansions=4785, matches_considered=76328

Delta: -15% expansions, -27% matches considered
