### PR TITLE
return dfa from `compress`

### DIFF
--- a/src/cli.jl
+++ b/src/cli.jl
@@ -84,7 +84,7 @@ function cli()
 
     size_by_symbol = Dict(Symbol(k) => Float32(v) for (k, v) in size_by_symbol_json)
     dfa_valid_root_states = Set([Symbol(s) for s in JSON.parse(args["dfa-valid-root-states"])])
-    abstractions, corpus = compress_imperative(
+    abstractions, corpus, _ = compress_imperative(
         corpus,
         args["dfa"],
         iterations=args["iterations"],

--- a/src/search.jl
+++ b/src/search.jl
@@ -577,7 +577,7 @@ function compress(original_corpus; iterations=3, dfa=nothing, kwargs...)
         push!(abstractions, search_res.abstraction)
     end
     println("Total compression: ", size(original_corpus, config.size_by_symbol) / size(corpus, config.size_by_symbol), "x")
-    return abstractions, corpus
+    return abstractions, corpus, dfa
 end
 
 function compress_imperative(original_corpus, dfa_path; kwargs...)

--- a/tests/framework.jl
+++ b/tests/framework.jl
@@ -40,7 +40,7 @@ function proc_args(args)
 end
 
 function compute(corpus, kwargs, kwargs_specific; seed=nothing)
-    abstractions, compressed_corpus = compress(corpus; strict=strict, shuffle_expansions_seed=seed, kwargs_specific...)
+    abstractions, compressed_corpus, _ = compress(corpus; strict=strict, shuffle_expansions_seed=seed, kwargs_specific...)
     abstractions = [abstraction_to_list(x) for x in abstractions]
     return Dict(
         "args" => kwargs,


### PR DESCRIPTION
Time change from main to return-dfa
Before: Individual times: [36.39, 35.31, 36.04, 36.1, 36.53]. Median: 36.1
After: Individual times: [36.87, 36.1, 36.69, 36.41, 37.36]. Median: 36.69
Change: +1.6%


Within MOE