### PR TITLE
check abstraction names not present in corpus

### DIFF
--- a/src/search.jl
+++ b/src/search.jl
@@ -563,11 +563,26 @@ function add_abstraction_to_dfa(dfa, symbol, abstraction)
     dfa
 end
 
+function check_abstraction_names_not_present(corpus, names)
+    names_set = Set(names)
+    for program in corpus.programs
+        for node in subexpressions(program.expr)
+            if node.leaf !== nothing
+                continue
+            end
+            head = node.children[1].leaf
+            if head in names_set
+                error("abstraction name $head is already present in the corpus")
+            end
+        end
+    end
+end
 
 function compress(original_corpus; iterations=3, dfa=nothing, kwargs...)
     corpus = original_corpus
-    abstractions = Abstraction[]
     config = SearchConfig(; dfa=dfa, kwargs...)
+    check_abstraction_names_not_present(corpus, [config.abstraction_name_function(i) for i in 1:iterations])
+    abstractions = Abstraction[]
     for i in 1:iterations
         println("===Iteration $i===")
         config.new_abstraction_name = Symbol(config.abstraction_name_function(i))


### PR DESCRIPTION
Time change from main to check-head
Before: Individual times: [36.44, 37.3, 37.66, 38.39, 38.49]. Median: 37.66
After: Individual times: [37.26, 37.93, 37.21, 37.57, 37.72]. Median: 37.57
Change: -0.2%

No change in performance