### PR TITLE
delete the 3.11 dfa elements

### DIFF
--- a/data_for_testing/dfa_imp.json
+++ b/data_for_testing/dfa_imp.json
@@ -584,40 +584,6 @@
     "Lt": [],
     "LtE": [],
     "MatMult": [],
-    "Match": [
-      "X",
-      "X"
-    ],
-    "MatchAs": [
-      "X",
-      "X"
-    ],
-    "MatchClass": [
-      "X",
-      "X",
-      "X",
-      "X"
-    ],
-    "MatchMapping": [
-      "X",
-      "X",
-      "X"
-    ],
-    "MatchOr": [
-      "X"
-    ],
-    "MatchSequence": [
-      "X"
-    ],
-    "MatchSingleton": [
-      "X"
-    ],
-    "MatchStar": [
-      "X"
-    ],
-    "MatchValue": [
-      "X"
-    ],
     "Mod": [],
     "Module": [
       "X",
@@ -690,12 +656,6 @@
       "X",
       "X"
     ],
-    "TryStar": [
-      "X",
-      "X",
-      "X",
-      "X"
-    ],
     "Tuple": [
       "X",
       "X"
@@ -759,14 +719,8 @@
       "X",
       "X"
     ],
-    "match_case": [
-      "X",
-      "X",
-      "X"
-    ],
     "mod": [],
     "operator": [],
-    "pattern": [],
     "slice": [],
     "stmt": [],
     "type_ignore": [],


### PR DESCRIPTION
Time change from main to slightly-smaller-dfa
Before: Individual times: [41.84, 42.05, 41.9, 42.46, 43.18]. Median: 42.05
After: Individual times: [43.74, 43.28, 42.16, 41.83, 41.77]. Median: 42.16
Change: +0.3%
