### PR TITLE
clean up strict domination

### DIFF
--- a/src/expand.jl
+++ b/src/expand.jl
@@ -1029,7 +1029,11 @@ hole_struct_hash(x::RemainingSequenceHole) = (:RemainingSequenceHole, (x.root_no
 
 # https://arxiv.org/pdf/2211.16605.pdf (section 4.3)
 function strictly_dominated(search_state)
-    redundant_arg_elim(search_state) || arg_capture(search_state) || choice_var_always_used_or_not(search_state) || variables_at_front_of_root_sequence(search_state)
+    redundant_arg_elim(search_state) && return true
+    arg_capture(search_state) && return true
+    choice_var_always_used_or_not(search_state) && return true
+    variables_at_front_of_root_sequence(search_state) && return true
+    false
 end
 
 # https://arxiv.org/pdf/2211.16605.pdf (section 4.3)


### PR DESCRIPTION
Within MOE

Time change from main to clean-up-strict-dominated
Before: Individual times: [50.01, 51.04, 49.43, 50.7, 50.42]. Median: 50.42
After: Individual times: [50.82, 51.36, 51.87, 51.26, 51.01]. Median: 51.26
Change: +1.7%
