### PR TITLE
ban choice vars adjacent to each other

### DIFF
--- a/src/expand.jl
+++ b/src/expand.jl
@@ -1158,14 +1158,10 @@ function choice_vars_adjacent_to_each_other_at_top_level(exprs)
 end
 
 function is_choice_var(expr)
-    if expr.leaf === nothing
-        return false
-    end
+    expr.leaf === nothing && return false
+    expr.leaf == SYM_HOLE && return false
     l = string(expr.leaf)
-    if l[1] == '?'
-        return true
-    end
-    return false
+    return l[1] == '?'
 end
 
 function choice_var_always_used_or_not(search_state::SearchState{Match}, i)

--- a/src/expand.jl
+++ b/src/expand.jl
@@ -1032,6 +1032,7 @@ function strictly_dominated(search_state)
     redundant_arg_elim(search_state) && return true
     arg_capture(search_state) && return true
     choice_var_always_used_or_not(search_state) && return true
+    choice_vars_adjacent_to_each_other(search_state) && return true
     variables_at_front_of_root_sequence(search_state) && return true
     false
 end
@@ -1130,6 +1131,41 @@ function choice_var_always_used_or_not(search_state)
         end
     end
     false
+end
+
+function choice_vars_adjacent_to_each_other(search_state::SearchState{T}) where {T}
+    search_state.config.max_choicevar_length < typemax(Int) && return false
+    search_state.abstraction.choice_arity < 2 && return false
+    choice_vars_adjacent_to_each_other(search_state.abstraction.body)
+end
+
+function choice_vars_adjacent_to_each_other(expr::SExpr)
+    expr.leaf === nothing || return false
+    head = expr.children[1].leaf
+    if head == SYM_SEQ_HEAD || head == SYM_SUBSEQ_HEAD
+        return choice_vars_adjacent_to_each_other_at_top_level(expr.children[2:end])
+    end
+    return any(choice_vars_adjacent_to_each_other, expr.children)
+end
+
+function choice_vars_adjacent_to_each_other_at_top_level(exprs)
+    for i in 1:length(exprs)-1
+        if is_choice_var(exprs[i]) && is_choice_var(exprs[i+1])
+            return true
+        end
+    end
+    return false
+end
+
+function is_choice_var(expr)
+    if expr.leaf === nothing
+        return false
+    end
+    l = string(expr.leaf)
+    if l[1] == '?'
+        return true
+    end
+    return false
 end
 
 function choice_var_always_used_or_not(search_state::SearchState{Match}, i)


### PR DESCRIPTION
Within MOE, but probably still good for consistency in cases where there's more than 2 choicevars

Time change from clean-up-strict-dominated to choice-vars-adjacent-to-each-other
Before: Individual times: [50.82, 51.36, 51.87, 51.26, 51.01]. Median: 51.26
After: Individual times: [50.49, 49.25, 50.33, 49.91, 49.33]. Median: 49.91
Change: -2.6%
