### PR TITLE
use a dictionary for metavariable expansions

### DIFF
--- a/src/expand.jl
+++ b/src/expand.jl
@@ -210,26 +210,28 @@ function collect_expansions(
     if isnothing(config.dfa)
         collect_abstraction_expansions_for_dfa_state!(matches, :uninit_state)
     else
-        matches_e = Vector{Tuple{Int,Match}}()
-        matches_s = Vector{Tuple{Int,Match}}()
-        matches_seqS = Vector{Tuple{Int,Match}}()
+        matches_for_state = Dict{Symbol, Vector{Tuple{Int,Match}}}()
         for (i, match) in matches
             hole = match.holes[end]
             if typeof(hole) != TreeNodeHole
                 continue
             end
             dfa_state = hole.metadata.dfa_state
-            if dfa_state === :E
-                push!(matches_e, (i, match))
-            elseif config.dfa_metavariable_allow_S && dfa_state === :S
-                push!(matches_s, (i, match))
-            elseif config.dfa_metavariable_allow_seqS && dfa_state === :seqS
-                push!(matches_seqS, (i, match))
+            allowed = (
+                dfa_state === :E
+                || (config.dfa_metavariable_allow_S && dfa_state === :S)
+                || (config.dfa_metavariable_allow_seqS && dfa_state === :seqS)
+            )
+            if allowed
+                matches_for_this_state = get!(matches_for_state, dfa_state) do
+                    Vector{Tuple{Int,Match}}()
+                end
+                push!(matches_for_this_state, (i, match))
             end
         end
-        collect_abstraction_expansions_for_dfa_state!(matches_e, :E)
-        config.dfa_metavariable_allow_S && collect_abstraction_expansions_for_dfa_state!(matches_s, :S)
-        config.dfa_metavariable_allow_seqS && collect_abstraction_expansions_for_dfa_state!(matches_seqS, :seqS)
+        for (state, ms) in matches_for_state
+            collect_abstraction_expansions_for_dfa_state!(ms, state)
+        end
     end
     result
 end


### PR DESCRIPTION
Time change from main to use-dictionary-metavar-expansions
Before: Individual times: [53.61, 53.54, 54.07, 53.31, 53.39]. Median: 53.54
After: Individual times: [52.39, 51.59, 52.47, 52.46, 52.06]. Median: 52.39
Change: -2.1%
