### PR TITLE
no choicevars at end

### DIFF
--- a/src/expand.jl
+++ b/src/expand.jl
@@ -1224,10 +1224,14 @@ function variables_at_front_of_root_sequence(search_state)
         return false
     end
     second_child = ab.children[2]
-    if second_child.leaf === nothing
-        return false
+    if second_child.leaf !== nothing && is_variable(second_child; no_metavar=first_child.leaf == SYM_SEQ_HEAD)
+        return true
     end
-    return is_variable(second_child; no_metavar=first_child.leaf == SYM_SEQ_HEAD)
+    last_child = ab.children[end]
+    if last_child.leaf !== nothing && is_variable(last_child; no_metavar=first_child.leaf == SYM_SEQ_HEAD)
+        return true
+    end
+    false
 end
 
 function is_variable(expr; no_metavar)


### PR DESCRIPTION
Somehow this doesn't help the timing at all. I'm guessing it is because a choicevar at the end allows you to quickly estimate how useful a given abstraction is, since you won't branch on it anyway.

Before: Individual times: [87.8, 89.04, 91.75, 90.66, 90.52]. Median: 90.52
After: Individual times: [93.72, 93.73, 94.41, 94.94, 89.86]. Median: 93.73
Change: +3.5%

On A.json:

Before: expansions=1525590, expansions=1875579, expansions=263492; total=3664661
After: expansions=1525590, expansions=1875579, expansions=263573; total=3664742

It seems like it in general doesn't even reduce the number of expansions, in general
