### PR TITLE
rectangle optimization function

### DIFF
--- a/src/search.jl
+++ b/src/search.jl
@@ -127,7 +127,7 @@ Base.@kwdef mutable struct SearchConfig
     track::Union{SExpr,Nothing} = nothing
     max_arity::Int = 2
     max_choice_arity::Int = 2
-    upper_bound_fn::Function = upper_bound_sum_no_variables
+    upper_bound_fn::Function = upper_bound_sum_no_variables_rectangle
     expansion_processor::Union{Function,Nothing} = nothing
     verbose::Bool = false
     verbose_best::Bool = true


### PR DESCRIPTION
Seems to not help as much as I'd like :sob: 

## Timing

Time change from main to rectangle-optimization-function
Before: Individual times: [68.82, 68.81, 68.57, 68.94, 69.36]. Median: 68.82
After: Individual times: [70.57, 71.12, 70.49, 71.16, 71.85]. Median: 71.12
Change: +3.3%

## On A.json:

Before:
expansions=1525590; expansions=1875579; expansions=263492; total=3664661
matches_considered=24280781; matches_considered=28643251; matches_considered=6532827; total=59456859

After:
expansions=1497819; expansions=1853614; expansions=262767; total=3614200
matches_considered=23844681; matches_considered=28269563; matches_considered=6530783; total=58645027

-1.3% expansions
-1.3% matches considered