### PR TITLE
pass config to expand_abstraction! and unexpand_abstraction!

### DIFF
--- a/src/expand.jl
+++ b/src/expand.jl
@@ -455,7 +455,7 @@ function check_number_of_holes(search_state)
 end
 
 function expand!(search_state::SearchState{Match}, expansion, hole)
-    expand_abstraction!(expansion, hole, search_state.holes, search_state.abstraction)
+    expand_abstraction!(expansion, hole, search_state.holes, search_state.abstraction, search_state.config)
     for match in search_state.matches
         extras = expand_match!(search_state.config, expansion, match)
         @assert extras === nothing
@@ -464,7 +464,7 @@ end
 
 function expand!(search_state::SearchState{MatchPossibilities}, expansion, hole)
 
-    expand_abstraction!(expansion, hole, search_state.holes, search_state.abstraction)
+    expand_abstraction!(expansion, hole, search_state.holes, search_state.abstraction, search_state.config)
     new_match_poss = MatchPossibilities[]
     whole_list_update = false
     for (idx, match_poss) in enumerate(search_state.matches)
@@ -512,7 +512,7 @@ function expand!(search_state::SearchState{MatchPossibilities}, expansion, hole)
     search_state.matches = new_match_poss
 end
 
-function expand_abstraction!(expansion::SyntacticLeafExpansion, hole, holes, abstraction)
+function expand_abstraction!(expansion::SyntacticLeafExpansion, hole, holes, abstraction, config::SearchConfig)
     # set the head symbol of the hole
     hole.leaf = expansion.leaf
 end
@@ -525,7 +525,7 @@ function expand_match!(config::SearchConfig, expansion::SyntacticLeafExpansion, 
     return nothing
 end
 
-function expand_abstraction!(expansion::SyntacticNodeExpansion, hole, holes, abstraction)
+function expand_abstraction!(expansion::SyntacticNodeExpansion, hole, holes, abstraction, config::SearchConfig)
     # make it no longer a leaf
     hole.leaf = nothing
 
@@ -572,7 +572,7 @@ function expand_match!(config::SearchConfig, expansion::SyntacticNodeExpansion, 
 end
 
 
-function expand_abstraction!(expansion::AbstractionExpansion, hole, holes, abstraction)
+function expand_abstraction!(expansion::AbstractionExpansion, hole, holes, abstraction, config::SearchConfig)
     hole.leaf = Symbol("#$(expansion.index)")
 
     if expansion.fresh
@@ -591,7 +591,7 @@ function expand_match!(config::SearchConfig, expansion::AbstractionExpansion, ma
     return nothing
 end
 
-function expand_abstraction!(expansion::SymbolExpansion, hole, holes, abstraction)
+function expand_abstraction!(expansion::SymbolExpansion, hole, holes, abstraction, config::SearchConfig)
     # set the head symbol of the hole
     hole.leaf = Symbol("%$(expansion.idx)")
 
@@ -618,7 +618,7 @@ function expand_match!(config::SearchConfig, expansion::SymbolExpansion, match::
 end
 
 
-function expand_abstraction!(expansion::SequenceExpansion, hole, holes, abstraction)
+function expand_abstraction!(expansion::SequenceExpansion, hole, holes, abstraction, config::SearchConfig)
     # take a hole ?? and make it (/seq ...). The hole is then pushed to the stack
     hole.leaf = nothing
     head = new_hole((hole, 1))
@@ -685,7 +685,7 @@ function insert_before_sequence_hole!(create_new, hole, holes)
     new_element
 end
 
-function expand_abstraction!(expansion::SequenceElementExpansion, hole, holes, abstraction)
+function expand_abstraction!(expansion::SequenceElementExpansion, hole, holes, abstraction, config::SearchConfig)
     element_hole = insert_before_sequence_hole!(i -> new_hole((hole, i)), hole, holes)
     push!(holes, element_hole)
 end
@@ -704,7 +704,7 @@ function expand_match!(config::SearchConfig, expansion::SequenceElementExpansion
     return nothing
 end
 
-function expand_abstraction!(expansion::SequenceTerminatorExpansion, hole, holes, abstraction)
+function expand_abstraction!(expansion::SequenceTerminatorExpansion, hole, holes, abstraction, config::SearchConfig)
     # just remove the last hole, and implicitly close off the sequence
     pop!(hole.children)
 end
@@ -725,7 +725,7 @@ function expand_match!(config::SearchConfig, expansion::SequenceTerminatorExpans
     return nothing
 end
 
-function expand_abstraction!(expansion::SequenceChoiceVarExpansion, hole, holes, abstraction)
+function expand_abstraction!(expansion::SequenceChoiceVarExpansion, hole, holes, abstraction, config::SearchConfig)
     # take a hole (/seq <things> ...) and make it (/seq <things> ?? ...). Place the ?? above the ... on the stack,
     # but do *not* remove ... from the stack, since it will be consumed by the next expansion once the ?? is filled in
 
@@ -780,14 +780,14 @@ function expand_match!(config::SearchConfig, expansion::SequenceChoiceVarExpansi
 end
 
 function unexpand!(search_state::SearchState{Match}, expansion, hole)
-    unexpand_abstraction!(expansion, hole, search_state.holes, search_state.abstraction)
+    unexpand_abstraction!(expansion, hole, search_state.holes, search_state.abstraction, search_state.config)
     for match in search_state.matches
         unexpand_match!(expansion, match)
     end
 end
 
 function unexpand!(search_state::SearchState{MatchPossibilities}, expansion, hole)
-    unexpand_abstraction!(expansion, hole, search_state.holes, search_state.abstraction)
+    unexpand_abstraction!(expansion, hole, search_state.holes, search_state.abstraction, search_state.config)
     search_state.matches = pop!(search_state.matches_stack)
     for match_poss in search_state.matches
         for match in match_poss.alternatives
@@ -796,7 +796,7 @@ function unexpand!(search_state::SearchState{MatchPossibilities}, expansion, hol
     end
 end
 
-function unexpand_abstraction!(expansion::SyntacticLeafExpansion, hole, holes, abstraction)
+function unexpand_abstraction!(expansion::SyntacticLeafExpansion, hole, holes, abstraction, config::SearchConfig)
     hole.leaf = SYM_HOLE
 end
 
@@ -807,7 +807,7 @@ function unexpand_match!(expansion::SyntacticLeafExpansion, match::Match)
     match.holes_size += hole.metadata.size
 end
 
-function unexpand_abstraction!(expansion::SyntacticNodeExpansion, hole, holes, abstraction)
+function unexpand_abstraction!(expansion::SyntacticNodeExpansion, hole, holes, abstraction, config::SearchConfig)
     hole.leaf = SYM_HOLE
 
     # pop from .args and holes
@@ -839,7 +839,7 @@ function unexpand_match!(expansion::SyntacticNodeExpansion, match::Match)
     end
 end
 
-function unexpand_abstraction!(expansion::AbstractionExpansion, hole, holes, abstraction)
+function unexpand_abstraction!(expansion::AbstractionExpansion, hole, holes, abstraction, config::SearchConfig)
     hole.leaf = SYM_HOLE
     if expansion.fresh
         abstraction.arity -= 1
@@ -857,7 +857,7 @@ function unexpand_match!(expansion::AbstractionExpansion, match::Match)
     match.holes_size += hole.metadata.size
 end
 
-function unexpand_abstraction!(expansion::SymbolExpansion, hole, holes, abstraction)
+function unexpand_abstraction!(expansion::SymbolExpansion, hole, holes, abstraction, config::SearchConfig)
     # set the head symbol of the hole
     hole.leaf = SYM_HOLE
     if expansion.fresh
@@ -878,7 +878,7 @@ function unexpand_match!(expansion::SymbolExpansion, match::Match)
     match.holes_size += hole.metadata.size
 end
 
-function unexpand_abstraction!(expansion::SequenceExpansion, hole, holes, abstraction)
+function unexpand_abstraction!(expansion::SequenceExpansion, hole, holes, abstraction, config::SearchConfig)
     pop!(holes) === hole || error("expected same hole")
 
     # remove the ... and /seq from the sequence
@@ -934,7 +934,7 @@ function remove_inserted_before_sequence_hole!(check_fn, hole, holes)
     pop!(holes) === hole || error("expected same sequence")
 end
 
-function unexpand_abstraction!(expansion::SequenceElementExpansion, hole, holes, abstraction)
+function unexpand_abstraction!(expansion::SequenceElementExpansion, hole, holes, abstraction, config::SearchConfig)
     # remove the ?? hole from the list of holes
     pop!(holes).leaf === SYM_HOLE || error("expected SYM_HOLE")
 
@@ -953,7 +953,7 @@ function unexpand_match!(expansion::SequenceElementExpansion, match::Match)
     # doesn't affect holes_size since we are just replacing a ?? and ... with a ...
 end
 
-function unexpand_abstraction!(expansion::SequenceTerminatorExpansion, hole, holes, abstraction)
+function unexpand_abstraction!(expansion::SequenceTerminatorExpansion, hole, holes, abstraction, config::SearchConfig)
     # just put a ... on the stack and at the end of the sequence
     new_hole = new_seq_hole((hole, length(hole.children) + 1))
     push!(hole.children, new_hole)
@@ -973,7 +973,7 @@ function unexpand_match!(expansion::SequenceTerminatorExpansion, match::Match)
     # doesn't affect holes_size since we are just adding a ... that currently matches nothing
 end
 
-function unexpand_abstraction!(expansion::SequenceChoiceVarExpansion, hole, holes, abstraction)
+function unexpand_abstraction!(expansion::SequenceChoiceVarExpansion, hole, holes, abstraction, config::SearchConfig)
     remove_inserted_before_sequence_hole!(hole, holes) do m
         m.leaf == Symbol("?$(expansion.idx)") || error("expected Symbol(?$(expansion.idx)), got $m")
     end


### PR DESCRIPTION
Time change from main to pass-config-to-expand-unexpand
Before: Individual times: [68.42, 68.54, 69.18, 67.4, 66.88]. Median: 68.42
After: Individual times: [65.9, 66.75, 66.57, 65.84, 67.0]. Median: 66.57
Change: -2.7%

Within margin of error