### PR TITLE
invalid optimization: subtract match holes

### DIFF
--- a/src/search.jl
+++ b/src/search.jl
@@ -413,7 +413,10 @@ function stitch_search(corpus, config)
         expansion = pop!(search_state.expansions)
 
         # upper bound check
-        if config.upper_bound_fn(search_state, expansion) <= search_state.best_util
+        ub = config.upper_bound_fn(search_state, expansion)
+        # println("for abstraction: ", search_state.abstraction.body, " expansion: ", expansion.data)
+        # println("upper bound: ", ub)
+        if ub <= search_state.best_util
             is_tracked_pruned(search_state, expansion=expansion, message="$(@__FILE__):$(@__LINE__) - upper bound $(config.upper_bound_fn(search_state,expansion)) <= best util $(search_state.best_util)")
             plot && push!(plot_data.pruned_bound, (search_state.stats.expansions, config.upper_bound_fn(search_state, expansion)))
             continue # skip - worse than best so far

--- a/src/utility.jl
+++ b/src/utility.jl
@@ -104,8 +104,14 @@ function upper_bound_sum_no_variables(search_state, expansion=nothing)::Float32
         return 0
     end
 
-    sum(sum_no_variables, matches, init=0.0) - search_state.abstraction.body_size
+    # an amount that, if subtracted, will make matches[1] have the same utility as its local utility
+    excess_hole_size = minimum([holes_size(m) for m in matches])
+
+    sum(sum_no_variables, matches, init=0.0) - search_state.abstraction.body_size - excess_hole_size
 end
+
+holes_size(match::Match) = match.holes_size
+holes_size(match::MatchPossibilities) = maximum([m.holes_size for m in match.alternatives])
 
 sum_no_variables(match::Match) = max(match.local_utility + match.holes_size, 0)
 sum_no_variables(match::MatchPossibilities) = maximum([sum_no_variables(x) for x in match.alternatives])


### PR DESCRIPTION
this is bad because it doesn't handle the case where variables are reused, causing the utility to be greater than the size of all the holes in all but one match