### PR TITLE
utility of the end items

### DIFF
--- a/data/imperative/subsequence-in-start-and-end-items.json-out.json
+++ b/data/imperative/subsequence-in-start-and-end-items.json-out.json
@@ -3,9 +3,18 @@
         "args": {
             "match_sequences": true
         },
-        "abstractions": [],
+        "abstractions": [
+            [
+                0,
+                0,
+                "(/subseq a b c)",
+                "uninit_state",
+                [],
+                []
+            ]
+        ],
         "programs": [
-            "(/seq x y z (/seq 0 a b c 1) a b c 9 (/seq 2 a b c 3) d e f)"
+            "(/seq x y z (/seq 0 (/splice (fn_1)) 1) (/splice (fn_1)) 9 (/seq 2 (/splice (fn_1)) 3) d e f)"
         ]
     }
 ]

--- a/src/expand.jl
+++ b/src/expand.jl
@@ -1105,31 +1105,35 @@ end
 function arg_capture(search_state)
     search_state.config.no_opt_arg_capture && return false
     for i in 1:search_state.abstraction.arity
-        if arg_capture(search_state, i)
+        if arg_capture(search_state, match -> match.unique_args[i])
             return true
         end
     end
     false
 end
 
-function arg_capture(search_state::SearchState{Match}, i)
+function arg_capture(search_state::SearchState{Match}, arg_extract_fn)
     first_match = search_state.matches[1]
-    first_match_expr = first_match.unique_args[i]
-    if all(match -> same_in_context(first_match, match, first_match_expr, match.unique_args[i]), search_state.matches)
+    first_match_expr = arg_extract_fn(first_match)
+    if all(match -> same_in_context(first_match, match, first_match_expr, arg_extract_fn(match)), search_state.matches)
         return true
     end
     return false
 end
 
-function arg_capture(search_state::SearchState{MatchPossibilities}, i)
+function arg_capture(search_state::SearchState{MatchPossibilities}, arg_extract_fn)
     first_match = search_state.matches[1].alternatives[1]
-    first_match_expr = first_match.unique_args[i]
+    first_match_expr = arg_extract_fn(first_match)
     if all(
-        match_poss -> all(match -> same_in_context(match, first_match, match.unique_args[i], first_match_expr), match_poss.alternatives),
+        match_poss -> all(match -> same_in_context(match, first_match, arg_extract_fn(match), first_match_expr), match_poss.alternatives),
         search_state.matches
     )
         return true
     end
+    return false
+end
+
+function same_in_context(m1::Match, m2::Match, e1::Nothing, e2::SExpr)
     return false
 end
 

--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -111,6 +111,9 @@ function compute_best_utility(rcis::MultiRewriteConflictInfo, m::Match)::Tuple{F
     if m.start_items !== nothing
         args = vcat(args, expr_of(m).children[1:m.start_items])
     end
+    if m.end_items !== nothing
+        args = vcat(args, expr_of(m).children[m.end_items+1:end])
+    end
     util = m.local_utility + sum(arg -> rcis[arg.metadata.id].cumulative_utility, args, init=0.0)
     return util, m
 end


### PR DESCRIPTION
Honestly not sure why it was working before; I guess this condition just never came up. It comes up in the test I added in #120

Time change from main to end-items-utility
Before: Individual times: [64.9, 64.73, 65.08, 64.7, 63.08]. Median: 64.73
After: Individual times: [64.34, 63.98, 63.29, 64.06, 64.48]. Median: 64.06
Change: -1.0%

On A.json:

Before:

Total number expansions: 1740854
Total number matches considered: 33974451

After:
Total number expansions: 1740854
Total number matches considered: 33974451

No impact whatsoever. Presumably this never came up at any point in the search. Possibly it's because having the same thing match at different levels of nesting is rare?
