### PR TITLE
add incorrect test case for end items utility inclusion

### DIFF
--- a/data/imperative/subsequence-in-start-and-end-items.json
+++ b/data/imperative/subsequence-in-start-and-end-items.json
@@ -1,0 +1,3 @@
+[
+    "(/seq x y z (/seq 0 a b c 1) a b c 9 (/seq 2 a b c 3) d e f)"
+]

--- a/data/imperative/subsequence-in-start-and-end-items.json-args.json
+++ b/data/imperative/subsequence-in-start-and-end-items.json-args.json
@@ -1,0 +1,5 @@
+[
+    {
+        "match_sequences": true
+    }
+]

--- a/data/imperative/subsequence-in-start-and-end-items.json-out.json
+++ b/data/imperative/subsequence-in-start-and-end-items.json-out.json
@@ -1,0 +1,11 @@
+[
+    {
+        "args": {
+            "match_sequences": true
+        },
+        "abstractions": [],
+        "programs": [
+            "(/seq x y z (/seq 0 a b c 1) a b c 9 (/seq 2 a b c 3) d e f)"
+        ]
+    }
+]


### PR DESCRIPTION
this test should identify the abstraction (/subseq a b c) but does not because it doesn't take into account the utility of the end items.